### PR TITLE
fix(init): use text/template

### DIFF
--- a/src/initramfs/cmd/init/pkg/security/cis/cis.go
+++ b/src/initramfs/cmd/init/pkg/security/cis/cis.go
@@ -3,9 +3,9 @@ package cis
 import (
 	"bytes"
 	"encoding/base64"
-	"html/template"
 	"io/ioutil"
 	"math/rand"
+	"text/template"
 	"time"
 
 	"k8s.io/api/core/v1"

--- a/src/initramfs/cmd/init/pkg/system/services/kubeadm.go
+++ b/src/initramfs/cmd/init/pkg/system/services/kubeadm.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
+	"text/template"
 	"io/ioutil"
 	"log"
 	"os"


### PR DESCRIPTION
Fixes an issue where the rendered encryptionconfig.yaml could contain invalid
base64 data.