### PR TITLE
feat(image): build AMI with random.trust_cpu=on

### DIFF
--- a/src/image/src/packer.json
+++ b/src/image/src/packer.json
@@ -64,7 +64,7 @@
                 "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\"",
                 "sudo apt-get -y update",
                 "sudo apt-get -y install docker-ce",
-                "sudo docker run --privileged --volume /dev:/dev autonomy/talos:{{ user `version` }} image -b /dev/xvdf -f -p aws -u none"
+                "sudo docker run --privileged --volume /dev:/dev autonomy/talos:{{ user `version` }} image -b /dev/xvdf -f -p aws -u none -e 'random.trust_cpu=on'"
             ]
         }
     ]


### PR DESCRIPTION
This is a touchy subject. The Linux community seems split on enabling this. As a security centric distro, I'm hesitant to enable this by default. Without this though, our users will experience painfully slow startup times.