### PR TITLE
fix(osctl): compile static binary with CGO enabeld

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,7 +235,7 @@ ARG SHA
 ARG TAG
 ARG VERSION_PKG="github.com/autonomy/talos/internal/pkg/version"
 WORKDIR /src/internal/app/osctl
-RUN GOOS=linux GOARCH=amd64 go build -a -ldflags "-s -w -X ${VERSION_PKG}.Name=Client -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /osctl-linux-amd64
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -a -ldflags "-s -w -linkmode external -extldflags \"-static\" -X ${VERSION_PKG}.Name=Client -X ${VERSION_PKG}.SHA=${SHA} -X ${VERSION_PKG}.Tag=${TAG}" -o /osctl-linux-amd64
 RUN chmod +x /osctl-linux-amd64
 FROM scratch AS osctl-linux-amd64
 COPY --from=osctl-linux-amd64-build /osctl-linux-amd64 /osctl-linux-amd64


### PR DESCRIPTION
Without CGO, on linux/amd64, we cannot lookup the current user.