### PR TITLE
fix: add libblkid to the rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN make \
     INSTALL_GROUP=0 \
     LOCAL_CONFIGURE_OPTIONS="--prefix=/"
 RUN make install DESTDIR=/rootfs
+# libblkid
+RUN cp /toolchain/lib/libblkid.* /rootfs/lib
 # libuuid
 RUN cp /toolchain/lib/libuuid.* /rootfs/lib
 # gcompat


### PR DESCRIPTION
Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>

Fixes an issue found by @bradbeam:

```
[    4.909748] [talos] [initramfs] Formatting Partition /dev/sda - ESP
Error loading sh[    4.917300] [talos] [initramfs] recovered from: exit status 127
[    4.917300] early boot failed
[    4.917300] main.main
[    4.917300]     /src/internal/app/init/main.go:257
[    4.917300] runtime.main
[    4.917300]     /toolchain/usr/local/go/src/runtime/proc.go:201
[    4.917300] runtime.goexit
[    4.917300]     /toolchain/usr/local/go/src/runtime/asm_amd64.s:1333
ared library lib[    4.952803] [talos] [initramfs] rebooting in 10 seconds
blkid.so.1: No such file or directory (needed by /sbin/mkfs.xfs)
Error relocating /sbin/mkfs.xfs: blkid_new_probe_from_filename: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_probe_lookup_value: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_topology_get_minimum_io_size: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_do_fullprobe: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_topology_get_logical_sector_size: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_free_probe: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_topology_get_physical_sector_size: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_topology_get_alignment_offset: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_probe_enable_partitions: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_topology_get_optimal_io_size: symbol not found
Error relocating /sbin/mkfs.xfs: blkid_probe_get_topology: symbol not found
```