### PR TITLE
Renamecopy

### DIFF
--- a/internal/app/init/internal/platform/baremetal/baremetal.go
+++ b/internal/app/init/internal/platform/baremetal/baremetal.go
@@ -421,7 +421,13 @@ func (d *Device) Install() error {
 			default:
 				// nothing special, download and go
 				dst := strings.Split(artifact, "/")
-				err = os.Rename(out.Name(), filepath.Join(mountpoint, dst[len(dst)-1]))
+				outputFile, err := os.Create(filepath.Join(mountpoint, dst[len(dst)-1]))
+				if err != nil {
+					return err
+				}
+				defer outputFile.Close()
+
+				_, err = io.Copy(outputFile, out)
 				if err != nil {
 					return err
 				}

--- a/internal/app/init/internal/platform/cloud/aws/aws.go
+++ b/internal/app/init/internal/platform/cloud/aws/aws.go
@@ -121,8 +121,8 @@ func (a *AWS) UserData() (userdata.UserData, error) {
 	return userdata.Download(AWSUserDataEndpoint)
 }
 
-// Prepare implements the platform.Platform interface.
-func (a *AWS) Prepare(data userdata.UserData) (err error) {
+// Prepare implements the platform.Platform interface and handles initial host preparation.
+func (a *AWS) Install(data userdata.UserData) (err error) {
 	return hostname()
 }
 
@@ -150,7 +150,7 @@ func hostname() (err error) {
 	return nil
 }
 
-// Install installs talos if necessary
-func (a *AWS) Install(data userdata.UserData) (err error) {
+// Install implements the platform.Platform interface and handles additional system setup.
+func (a *AWS) Prepare(data userdata.UserData) (err error) {
 	return nil
 }

--- a/internal/app/init/internal/platform/cloud/vmware/vmware.go
+++ b/internal/app/init/internal/platform/cloud/vmware/vmware.go
@@ -70,12 +70,12 @@ func (vmw *VMware) UserData() (data userdata.UserData, err error) {
 	return data, nil
 }
 
-// Prepare implements the platform.Platform interface.
+// Prepare implements the platform.Platform interface and handles initial host preparation.
 func (vmw *VMware) Prepare(data userdata.UserData) (err error) {
 	return nil
 }
 
-// Install installs talos
+// Install implements the platform.Platform interface and handles additional system setup.
 func (vmw *VMware) Install(data userdata.UserData) (err error) {
 	return nil
 }

--- a/internal/app/init/internal/rootfs/mount/mount.go
+++ b/internal/app/init/internal/rootfs/mount/mount.go
@@ -95,7 +95,7 @@ func (i *Initializer) MoveSpecial() (err error) {
 // stage.
 func (i *Initializer) InitOwned() (err error) {
 	var owned *mount.Points
-	if owned, err = mountpoints(); err != nil {
+	if owned, err = Mountpoints(); err != nil {
 		return errors.Errorf("error initializing owned block devices: %v", err)
 	}
 	i.owned = owned
@@ -215,15 +215,17 @@ func (i *Initializer) Switch() (err error) {
 	return nil
 }
 
-func mountpoints() (mountpoints *mount.Points, err error) {
+func Mountpoints() (mountpoints *mount.Points, err error) {
 	mountpoints = mount.NewMountPoints()
-	for _, name := range []string{constants.RootPartitionLabel, constants.DataPartitionLabel} {
+	for _, name := range []string{constants.RootPartitionLabel, constants.DataPartitionLabel, constants.BootPartitionLabel} {
 		var target string
 		switch name {
 		case constants.RootPartitionLabel:
 			target = "/"
 		case constants.DataPartitionLabel:
 			target = "/var"
+		case constants.BootPartitionLabel:
+			target = "/boot"
 		}
 
 		var dev *probe.ProbedBlockDevice

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -75,8 +75,9 @@ func initram() (err error) {
 	if data, err = p.UserData(); err != nil {
 		return err
 	}
-	// Perform rootfs/datafs installation if needed.
-	if err = p.Install(data); err != nil {
+	// Perform any tasks required by a particular platform.
+	log.Printf("performing platform specific tasks")
+	if err = p.Prepare(data); err != nil {
 		return err
 	}
 	// Mount the owned partitions.
@@ -84,9 +85,8 @@ func initram() (err error) {
 	if err = initializer.InitOwned(); err != nil {
 		return err
 	}
-	// Perform any tasks required by a particular platform.
-	log.Printf("performing platform specific tasks")
-	if err = p.Prepare(data); err != nil {
+	// Install handles additional system setup
+	if err = p.Install(data); err != nil {
 		return err
 	}
 	// Prepare the necessary files in the rootfs.

--- a/internal/pkg/blockdevice/blockdevice.go
+++ b/internal/pkg/blockdevice/blockdevice.go
@@ -99,3 +99,8 @@ func (bd *BlockDevice) RereadPartitionTable() error {
 
 	return nil
 }
+
+// Device returns the backing file for the block device
+func (bd *BlockDevice) Device() *os.File {
+	return bd.f
+}


### PR DESCRIPTION
- fix: Changing os.rename to io.copy
```
[    5.438979] [talos] [initramfs] Installing Partition /dev/sda - ESP
[    5.475660] [talos] [initramfs] recovered from: rename /tmp/vmlinuz /tmp/ESP/vmlinuz: invalid cross-device link
[    5.475660] early boot failed
[    5.475660] main.main
[    5.475660]     /src/internal/app/init/main.go:257
[    5.475660] runtime.main
[    5.475660]     /toolchain/usr/local/go/src/runtime/proc.go:201
[    5.475660] runtime.goexit
[    5.475660]     /toolchain/usr/local/go/src/runtime/asm_amd64.s:1333
```

refactor(init): Making use of platform.Prepare() and platform.Install()

- Refactor init to call `platform.Prepare()`, then let init handle mounting, and then call `platform.Install()`. This should allow any platform to do initial preparation for the host ( device/filesystem creation ) followed by whatever tasks are necessary to get the system installed/functional. This should address the following error due to ordering. 
```
[   39.089876] [talos] [initramfs] recovered from: symlink /root/etc/hosts -> /run/hosts: symlink /run/hosts /root/etc/hosts: no such file or directory
[   39.089876] early boot failed
[   39.089876] main.main
[   39.089876]     /src/internal/app/init/main.go:257
[   39.089876] runtime.main
[   39.089876]     /toolchain/usr/local/go/src/runtime/proc.go:201
[   39.089876] runtime.goexit
[   39.089876]     /toolchain/usr/local/go/src/runtime/asm_amd64.s:1333
```