### PR TITLE
fix: output userdata fails, ignore numcpu for kubeadm

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -78,6 +78,7 @@ func initram() (err error) {
 	log.Printf("retrieving the user data")
 	var data *userdata.UserData
 	if data, err = p.UserData(); err != nil {
+		log.Printf("encountered error reading userdata: %v", err)
 		return err
 	}
 	// Perform rootfs/datafs installation if needed.

--- a/internal/app/init/pkg/system/services/kubeadm.go
+++ b/internal/app/init/pkg/system/services/kubeadm.go
@@ -126,7 +126,7 @@ func (k *Kubeadm) Start(data *userdata.UserData) error {
 	args := runner.Args{
 		ID: k.ID(data),
 	}
-	ignore := "--ignore-preflight-errors=cri,kubeletversion,requiredipvskernelmodulesavailable"
+	ignore := "--ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable"
 	if data.IsBootstrap() {
 		args.ProcessArgs = []string{"kubeadm", "init", "--config=/etc/kubernetes/kubeadm-config.yaml", ignore, "--skip-token-print"}
 	} else {


### PR DESCRIPTION
Stuff I fixed last night but forgot to push. Just a couple of small changes. Want to make sure we're at least showing a message if userdata fetch fails (#386). The returned error in the check didn't actually output a message along the way. 

Also want to ignore number of cpus in kubeadm so we can do some testing on small instances to save dolla dolla bills, y'all.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>