### PR TITLE
feat: change AWS instance type to t2.micro

### DIFF
--- a/hack/installer/packer.json
+++ b/hack/installer/packer.json
@@ -7,7 +7,7 @@
             "type": "amazon-ebssurrogate",
             "region": "{{ user `region` }}",
             "ssh_pty": true,
-            "instance_type": "t2.small",
+            "instance_type": "t2.micro",
             "associate_public_ip_address": true,
             "ssh_username": "ubuntu",
             "ssh_timeout": "5m",


### PR DESCRIPTION
This PR move the AWS EC2 instance type from `t2.small` to `t2.micro`.
`t2.micro` is free under AWS free tier and cheaper than `t2.small`.
I've tested that the build on a `t2.micro` work and doesn't slow down the build at all.