### PR TITLE
feat: add route printing to osctl

### DIFF
--- a/internal/app/osctl/cmd/routes.go
+++ b/internal/app/osctl/cmd/routes.go
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// nolint: dupl,golint
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/autonomy/talos/internal/app/osctl/internal/client"
+	"github.com/autonomy/talos/internal/pkg/constants"
+	"github.com/spf13/cobra"
+)
+
+// routesCmd represents the net routes command
+var routesCmd = &cobra.Command{
+	Use:   "routes",
+	Short: "List network routes",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		creds, err := client.NewDefaultClientCredentials()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		c, err := client.NewClient(constants.OsdPort, creds)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if err := c.Routes(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(routesCmd)
+}

--- a/internal/app/osctl/internal/client/client.go
+++ b/internal/app/osctl/internal/client/client.go
@@ -235,3 +235,22 @@ func (c *Client) Version() (err error) {
 
 	return nil
 }
+
+// Routes implements the proto.OSDClient interface.
+func (c *Client) Routes() (err error) {
+	ctx := context.Background()
+	reply, err := c.client.Routes(ctx, &empty.Empty{})
+	if err != nil {
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "INTERFACE\tDESTINATION\tGATEWAY")
+	for _, r := range reply.Routes {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Interface, r.Destination, r.Gateway)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -14,6 +14,7 @@ service OSD {
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Restart(RestartRequest) returns (RestartReply) {}
+  rpc Routes(google.protobuf.Empty) returns (RoutesReply) {}
   rpc Stats(StatsRequest) returns (StatsReply) {}
   rpc Version(google.protobuf.Empty) returns (Data) {}
 }
@@ -71,3 +72,13 @@ message LogsRequest {
 
 // The response message containing the requested logs.
 message Data { bytes bytes = 1; }
+
+// The response message containing the routes.
+message RoutesReply { repeated Route routes = 1; }
+
+// The response message containing a route.
+message Route {
+  string interface = 1;
+  string destination = 2;
+  string gateway = 3;
+}


### PR DESCRIPTION
Just makes it easier to see how the routing table is setup on talos nodes.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>