### PR TITLE
Delay `gitmeta` execution in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-SHA := $(shell gitmeta git sha)
-TAG := $(shell gitmeta image tag)
-BUILT := $(shell gitmeta built)
-PUSH := $(shell gitmeta pushable)
+SHA = $(shell gitmeta git sha)
+TAG = $(shell gitmeta image tag)
+BUILT = $(shell gitmeta built)
+PUSH = $(shell gitmeta pushable)
 
 VPATH = $(PATH)
 KERNEL_IMAGE ?= autonomy/kernel:e8147aa
@@ -24,7 +24,7 @@ endif
 BINDIR ?= /usr/local/bin
 CONFORM_VERSION ?= v0.1.0-alpha.10
 
-COMMON_ARGS := --progress=plain
+COMMON_ARGS = --progress=plain
 COMMON_ARGS += --frontend=dockerfile.v0
 COMMON_ARGS += --local context=.
 COMMON_ARGS += --local dockerfile=.


### PR DESCRIPTION
Changing assignment of the following from `:=` to `=`:
  - `SHA`
  - `TAG`
  - `BUILT`
  - `PUSH`

Additionally, changing `COMMON_ARGS` as well, because the two last assignments depend on `SHA` and `TAG` and will force them to assign a variable value too early (i.e., before the dependency `gitmeta` has been installed).

This fixes the `make: gitmeta: Command not found` error that occurs before all dependencies are installed.

See http://www.gnu.org/software/make/manual/make.html#Flavors