### PR TITLE
docs: properly wrap layouts in html/body tags

### DIFF
--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -273,7 +272,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -282,4 +280,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/blockd/index.html
+++ b/docs/components/blockd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -292,7 +291,6 @@ Managing any other block device can be done via the <code>blockd</code> service.
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -301,4 +299,7 @@ Managing any other block device can be done via the <code>blockd</code> service.
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/index.html
+++ b/docs/components/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -274,7 +273,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -283,4 +281,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/init/index.html
+++ b/docs/components/init/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -303,7 +302,6 @@ There simply is no mechanism in place to do anything else.</p>
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -312,4 +310,7 @@ There simply is no mechanism in place to do anything else.</p>
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/kernel/index.html
+++ b/docs/components/kernel/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -282,7 +281,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -291,4 +289,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/kubeadm/index.html
+++ b/docs/components/kubeadm/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -287,7 +286,6 @@ By integrating with <code>kubeadm</code> natively, Talos stands to gain a strong
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -296,4 +294,7 @@ By integrating with <code>kubeadm</code> natively, Talos stands to gain a strong
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/osctl/index.html
+++ b/docs/components/osctl/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -297,7 +296,6 @@ With it you can do things like:</p>
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -306,4 +304,7 @@ With it you can do things like:</p>
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/osd/index.html
+++ b/docs/components/osd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -298,7 +297,6 @@ Based on the Principle of Least Privilege, <code>osd</code> provides operational
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -307,4 +305,7 @@ Based on the Principle of Least Privilege, <code>osd</code> provides operational
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/proxyd/index.html
+++ b/docs/components/proxyd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -287,7 +286,6 @@ The <code>proxyd</code> component is a simple yet powerful reverse proxy that ad
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -296,4 +294,7 @@ The <code>proxyd</code> component is a simple yet powerful reverse proxy that ad
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/components/trustd/index.html
+++ b/docs/components/trustd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -295,7 +294,6 @@ It can, for example, accept a write request from another node to place a file on
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -304,4 +302,7 @@ It can, for example, accept a write request from another node to place a file on
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/configuration/index.html
+++ b/docs/configuration/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -281,7 +280,6 @@ There are three major components we will configure:</p>
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -290,4 +288,7 @@ There are three major components we will configure:</p>
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/configuration/masters/index.html
+++ b/docs/configuration/masters/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -455,7 +454,6 @@ services:
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -464,4 +462,7 @@ services:
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/configuration/osd/index.html
+++ b/docs/configuration/osd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -383,7 +382,6 @@ contexts:
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -392,4 +390,7 @@ contexts:
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/configuration/workers/index.html
+++ b/docs/configuration/workers/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -316,7 +315,6 @@ services:
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -325,4 +323,7 @@ services:
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/examples/aws/index.html
+++ b/docs/examples/aws/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -297,7 +296,6 @@ Provide the proper configuration as the instance&rsquo;s user data.</p>
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -306,4 +304,7 @@ Provide the proper configuration as the instance&rsquo;s user data.</p>
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/examples/gcloud/index.html
+++ b/docs/examples/gcloud/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -306,7 +305,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -315,4 +313,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -275,7 +274,6 @@ In the following sections we will cover how to deploy Talos to well known platfo
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -284,4 +282,7 @@ In the following sections we will cover how to deploy Talos to well known platfo
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/examples/kvm/index.html
+++ b/docs/examples/kvm/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -354,7 +353,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -363,4 +361,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/examples/xen/index.html
+++ b/docs/examples/xen/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -362,7 +361,6 @@ extra = &quot;ip=dhcp consoleblank=0 console=hvc0 console=tty0 console=ttyS0,960
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -371,4 +369,7 @@ extra = &quot;ip=dhcp consoleblank=0 console=hvc0 console=tty0 console=ttyS0,960
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 	<meta name="generator" content="Hugo 0.49.2" />
 
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -259,8 +259,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -277,7 +276,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -286,4 +284,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10"></div>
@@ -273,7 +272,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -282,4 +280,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/docs/talos/index.html
+++ b/docs/talos/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="https://talos.autonomy.io//css/milligram.min.css">
     <link rel="stylesheet" href="https://talos.autonomy.io/css/main.css">
 </head>
-<nav class="navbar">
+<body><nav class="navbar">
     <div class="container">
         <div class="row">
             <div class="column column-50">
@@ -258,8 +258,7 @@
         </div>
     </div>
 </nav>
-<body>
-    <div class="container">
+<div class="container">
         <div class="content">
             <div class="row ">
                 <div class="column column-10">
@@ -278,7 +277,6 @@
             </div>
         </div>
     </div>
-</body>
 
 <div class="footer">
     <aside class="copyright">
@@ -287,4 +285,7 @@
         
     </aside>
 </div>
+</html>
 
+
+</body>

--- a/web/themes/autonomy/layouts/_default/list.html
+++ b/web/themes/autonomy/layouts/_default/list.html
@@ -1,10 +1,11 @@
 {{- partial "head" . -}}
 
+<body>
+
 {{- partial "navbar" . -}}
 
 {{- partial "sidebar" . -}}
 
-<body>
     <div class="container">
         <div class="content">
             <div class="row ">
@@ -19,6 +20,7 @@
             </div>
         </div>
     </div>
-</body>
 
 {{ partial "footer" . }}
+
+</body>

--- a/web/themes/autonomy/layouts/_default/single.html
+++ b/web/themes/autonomy/layouts/_default/single.html
@@ -1,10 +1,11 @@
 {{- partial "head" . -}}
 
+<body>
+
 {{- partial "navbar" . -}}
 
 {{- partial "sidebar" . -}}
 
-<body>
     <div class="container">
         <div class="content">
             <div class="row ">
@@ -31,6 +32,7 @@
             </div>
         </div>
     </div>
-</body>
 
 {{ partial "footer" . }}
+
+</body>

--- a/web/themes/autonomy/layouts/index.html
+++ b/web/themes/autonomy/layouts/index.html
@@ -1,10 +1,11 @@
 {{- partial "head" . -}}
 
+<body>
+
 {{- partial "navbar" . -}}
 
 {{- partial "sidebar" . -}}
 
-<body>
     <div class="container">
         <div class="content">
             <div class="row ">
@@ -21,6 +22,7 @@
             </div>
         </div>
     </div>
-</body>
 
 {{ partial "footer" . }}
+
+</body>

--- a/web/themes/autonomy/layouts/partials/footer.html
+++ b/web/themes/autonomy/layouts/partials/footer.html
@@ -5,3 +5,4 @@
         {{ end }}
     </aside>
 </div>
+</html>

--- a/web/themes/autonomy/layouts/partials/head.html
+++ b/web/themes/autonomy/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang="en">
 <head>
 
     <!-- Basic Page Needs


### PR DESCRIPTION
Signed-off-by: Tommy Nguyen <remyabel@gmail.com>

All documents need `<html>` tags. Also, the rest of the page needs to be wrapped in `<body>` which was in the wrong location. 