### PR TITLE
test: add kernel pkg tests, improve parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/spf13/afero v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
-	github.com/stretchr/testify v1.2.2 // indirect
+	github.com/stretchr/testify v1.2.2
 	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect
 	github.com/u-root/u-root v4.0.0+incompatible // indirect
 	github.com/vishvananda/netlink v1.0.0

--- a/internal/pkg/kernel/kernel_test.go
+++ b/internal/pkg/kernel/kernel_test.go
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package kernel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/autonomy/talos/internal/pkg/kernel"
+)
+
+type KernelSuite struct {
+	suite.Suite
+}
+
+func (suite *KernelSuite) TestParseKernelBootParameters() {
+	for _, t := range []struct {
+		params   []byte
+		expected map[string]string
+	}{
+		{[]byte(""), map[string]string{}},
+		{[]byte("boot=xyz root=/dev/abc nogui"), map[string]string{"boot": "xyz", "root": "/dev/abc", "nogui": ""}},
+		{[]byte(" root=/dev/abc=1  nogui  \n"), map[string]string{"root": "/dev/abc=1", "nogui": ""}},
+		{[]byte("root=/dev/sda root=/dev/sdb"), map[string]string{"root": "/dev/sdb"}},
+	} {
+		suite.Assert().Equal(t.expected, kernel.ParseKernelBootParameters(t.params))
+	}
+
+}
+
+func TestKernelSuite(t *testing.T) {
+	suite.Run(t, new(KernelSuite))
+}


### PR DESCRIPTION
First Go test added to the package, tests are based
on stretchr/testify, I feel it provides enough goodies
to use it instead of stdlib `testing` package, but
please let me know if it works. It makes sense to use
same testing framework for the whole codebase.

Kernel boot time params parsing was improved to handle
consecutive spaces and params without value.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>