### PR TITLE
feat: update gcc to 8.3.0, drop gcompat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PUSH = $(shell gitmeta pushable)
 
 VPATH = $(PATH)
 KERNEL_IMAGE ?= autonomy/kernel:e8147aa
-TOOLCHAIN_IMAGE ?= autonomy/toolchain:1cad5fc
+TOOLCHAIN_IMAGE ?= autonomy/toolchain:80f91fd
 GOLANG_VERSION ?= 1.11.4
 DOCKER_ARGS ?=
 BUILDKIT_VERSION ?= v0.3.3


### PR DESCRIPTION
fixes: #373

Toolchain image updated to the latest version (see PR
autonomy/toolchain-musl#5).

This drops dependency on `gcompat` which was causing issues on Linux
4.17+ and pre-built Go binaries are imported from official
`golang:XXX-alpine` image.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>