### PR TITLE
feat: add arg to target nodes per command

### DIFF
--- a/internal/app/osctl/cmd/dmesg.go
+++ b/internal/app/osctl/cmd/dmesg.go
@@ -32,6 +32,9 @@ var dmesgCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -45,5 +48,6 @@ var dmesgCmd = &cobra.Command{
 }
 
 func init() {
+	dmesgCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(dmesgCmd)
 }

--- a/internal/app/osctl/cmd/logs.go
+++ b/internal/app/osctl/cmd/logs.go
@@ -32,6 +32,9 @@ var logsCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Print(err)
@@ -56,5 +59,6 @@ var logsCmd = &cobra.Command{
 
 func init() {
 	logsCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	logsCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(logsCmd)
 }

--- a/internal/app/osctl/cmd/ps.go
+++ b/internal/app/osctl/cmd/ps.go
@@ -26,6 +26,9 @@ var psCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -46,5 +49,6 @@ var psCmd = &cobra.Command{
 
 func init() {
 	psCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	psCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(psCmd)
 }

--- a/internal/app/osctl/cmd/reboot.go
+++ b/internal/app/osctl/cmd/reboot.go
@@ -25,6 +25,9 @@ var rebootCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -38,5 +41,6 @@ var rebootCmd = &cobra.Command{
 }
 
 func init() {
+	rebootCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(rebootCmd)
 }

--- a/internal/app/osctl/cmd/reset.go
+++ b/internal/app/osctl/cmd/reset.go
@@ -25,6 +25,9 @@ var resetCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -38,5 +41,6 @@ var resetCmd = &cobra.Command{
 }
 
 func init() {
+	resetCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(resetCmd)
 }

--- a/internal/app/osctl/cmd/root.go
+++ b/internal/app/osctl/cmd/root.go
@@ -26,6 +26,7 @@ var (
 	hours        int
 	kubernetes   bool
 	talosconfig  string
+	target       string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/internal/app/osctl/cmd/routes.go
+++ b/internal/app/osctl/cmd/routes.go
@@ -25,6 +25,9 @@ var routesCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -39,5 +42,6 @@ var routesCmd = &cobra.Command{
 }
 
 func init() {
+	routesCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(routesCmd)
 }

--- a/internal/app/osctl/cmd/stats.go
+++ b/internal/app/osctl/cmd/stats.go
@@ -26,6 +26,9 @@ var statsCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		if target != "" {
+			creds.Target = target
+		}
 		c, err := client.NewClient(constants.OsdPort, creds)
 		if err != nil {
 			fmt.Println(err)
@@ -46,5 +49,6 @@ var statsCmd = &cobra.Command{
 
 func init() {
 	statsCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
+	statsCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	rootCmd.AddCommand(statsCmd)
 }

--- a/internal/app/osctl/internal/client/client.go
+++ b/internal/app/osctl/internal/client/client.go
@@ -24,7 +24,7 @@ import (
 // Credentials represents the set of values required to initialize a vaild
 // Client.
 type Credentials struct {
-	target string
+	Target string
 	ca     []byte
 	crt    []byte
 	key    []byte
@@ -58,7 +58,7 @@ func NewDefaultClientCredentials(p string) (creds *Credentials, err error) {
 		return
 	}
 	creds = &Credentials{
-		target: c.Contexts[c.Context].Target,
+		Target: c.Contexts[c.Context].Target,
 		ca:     caBytes,
 		crt:    crtBytes,
 		key:    keyBytes,
@@ -86,7 +86,7 @@ func NewClient(port int, clientcreds *Credentials) (c *Client, err error) {
 	// TODO(andrewrynhard): Do not parse the address. Pass the IP and port in as separate
 	// parameters.
 	creds := credentials.NewTLS(&tls.Config{
-		ServerName:   clientcreds.target,
+		ServerName:   clientcreds.Target,
 		Certificates: []tls.Certificate{crt},
 		// Set the root certificate authorities to use the self-signed
 		// certificate.
@@ -94,7 +94,7 @@ func NewClient(port int, clientcreds *Credentials) (c *Client, err error) {
 	})
 
 	grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(creds))
-	c.conn, err = grpc.Dial(fmt.Sprintf("%s:%d", clientcreds.target, port), grpcOpts...)
+	c.conn, err = grpc.Dial(fmt.Sprintf("%s:%d", clientcreds.Target, port), grpcOpts...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
closes #434 

Adds a `--target` (shorthand `-t`) to the command that communicate with nodes so direct the command at that node temporarily. Does not affect on-disk config.