### PR TITLE
fix: join masters in serial

### DIFF
--- a/internal/pkg/userdata/userdata.go
+++ b/internal/pkg/userdata/userdata.go
@@ -214,6 +214,7 @@ type Trustd struct {
 	Password  string   `yaml:"password"`
 	Endpoints []string `yaml:"endpoints,omitempty"`
 	CertSANs  []string `yaml:"certSANs,omitempty"`
+	Next      string   `yaml:"next,omitempty"`
 }
 
 // OSD describes the configuration of the osd service.


### PR DESCRIPTION
This introduces a new option in the trustd configuration. The field `next` was added to indicate to a master which node to send the PKI to.
 
Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>