### PR TITLE
hack/dev follow up

### DIFF
--- a/hack/dev/.gitignore
+++ b/hack/dev/.gitignore
@@ -2,3 +2,4 @@ pki/
 userdata/*
 !userdata/.*
 talosconfig
+kubeconfig

--- a/hack/dev/Makefile
+++ b/hack/dev/Makefile
@@ -13,19 +13,23 @@ all: up
 
 .PHONY: up
 up: talosconfig
-	@$(DOCKER_COMPOSE) up -d
+	@$(DOCKER_COMPOSE) up -d $(SERVICES)
 
 .PHONY: down
 down:
-	@$(DOCKER_COMPOSE) down -v
+	@$(DOCKER_COMPOSE) down -v $(SERVICES)
 
 talosconfig:
 	@mkdir -p pki
 	@./gen.sh $(IP_ADDR)
 
+kubeconfig:
+	@$(DOCKER_COMPOSE) run --rm osctl kubeconfig > kubeconfig
+
 .PHONY: clean
 clean: down
 	-@rm talosconfig
+	-@rm kubeconfig
 	-@rm userdata/master-1.yaml
 	-@rm userdata/master-2.yaml
 	-@rm userdata/master-3.yaml

--- a/hack/dev/README.md
+++ b/hack/dev/README.md
@@ -1,0 +1,41 @@
+# Run a local talos cluster using docker
+
+```bash
+# standup HA cluster
+make
+
+# standup single-node k8s
+make SERVICES=master-1
+
+# use a specific image tag
+make TAG=<image_tag>
+
+
+# connect using ../../build/osctl-linux-amd64
+## master-1
+TAG= docker-compose run --rm osctl ps
+## master-2
+TAG= docker-compose run --rm osctl -t 10.5.0.7 ps
+
+
+# use kubectl
+make kubeconfig
+
+## apply PSP
+TAG= docker-compose run --rm kubectl apply -f ./manifests/psp.yaml
+## apply CNI
+TAG= docker-compose run --rm kubectl apply -f ./manifests/cni.yaml
+
+
+# read init logs  (container stdout equiv. to /dev/kmsg)
+docker-compose logs -f
+
+# export all logs directly from docker  (useful if osd is down or init is broken)
+sudo docker cp master-1:/var/log master-1-logs
+sudo chown -R $USER master-1-logs
+chmod -R +rw master-1-logs
+
+
+# cleanup
+make clean
+```

--- a/hack/dev/docker-compose.yaml
+++ b/hack/dev/docker-compose.yaml
@@ -1,6 +1,25 @@
 version: '3.7'
 
 services:
+  osctl:
+    image: alpine
+    entrypoint: /bin/osctl
+    command: version
+    volumes:
+      - ../../build/osctl-linux-amd64:/bin/osctl:ro
+      - ./talosconfig:/root/.talos/config
+    networks:
+      talosbr:
+
+  kubectl:
+    image: k8s.gcr.io/hyperkube:${HYPERKUBE_TAG:-v1.13.3}
+    entrypoint: kubectl
+    volumes:
+      - ./kubeconfig:/root/.kube/config
+      - ./manifests:/manifests
+    networks:
+      talosbr:
+
   master-1:
     image: ${IMAGE:-autonomy/talos-os}:${TAG}
     container_name: master-1

--- a/hack/dev/userdata/.master-1.tpl.yaml
+++ b/hack/dev/userdata/.master-1.tpl.yaml
@@ -28,6 +28,8 @@ services:
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
       failSwapOn: false  # necessary for some docker hosts
+      featureGates:
+        ExperimentalCriticalPodAnnotation: true
       ---
       apiVersion: kubeproxy.config.k8s.io/v1alpha1
       kind: KubeProxyConfiguration

--- a/hack/dev/userdata/.master-2.tpl.yaml
+++ b/hack/dev/userdata/.master-2.tpl.yaml
@@ -10,6 +10,7 @@ services:
   kubeadm:
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
+      kind: JoinConfiguration
       caCertPath: /etc/kubernetes/pki/ca.crt
       controlPlane:
         localAPIEndpoint:
@@ -22,11 +23,8 @@ services:
           unsafeSkipCAVerification: true
         timeout: 5m0s
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
-      kind: JoinConfiguration
       nodeRegistration:
-        criSocket: /var/run/dockershim.sock
-        kubeletExtraArgs:
-          feature-gates: ExperimentalCriticalPodAnnotation=true
+        criSocket: /run/containerd/containerd.sock
     extraArgs:
     - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
   trustd:

--- a/hack/dev/userdata/.master-3.tpl.yaml
+++ b/hack/dev/userdata/.master-3.tpl.yaml
@@ -10,6 +10,7 @@ services:
   kubeadm:
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
+      kind: JoinConfiguration
       caCertPath: /etc/kubernetes/pki/ca.crt
       controlPlane:
         localAPIEndpoint:
@@ -22,11 +23,8 @@ services:
           unsafeSkipCAVerification: true
         timeout: 5m0s
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
-      kind: JoinConfiguration
       nodeRegistration:
-        criSocket: /var/run/dockershim.sock
-        kubeletExtraArgs:
-          feature-gates: ExperimentalCriticalPodAnnotation=true
+        criSocket: /run/containerd/containerd.sock
     extraArgs:
     - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
   trustd:

--- a/hack/dev/userdata/.worker.tpl.yaml
+++ b/hack/dev/userdata/.worker.tpl.yaml
@@ -10,6 +10,7 @@ services:
   kubeadm:
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
+      kind: JoinConfiguration
       caCertPath: /etc/kubernetes/pki/ca.crt
       discovery:
         bootstrapToken:
@@ -18,12 +19,10 @@ services:
           unsafeSkipCAVerification: true
         timeout: 5m0s
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
-      kind: JoinConfiguration
       nodeRegistration:
-        criSocket: /var/run/dockershim.sock
+        criSocket: /run/containerd/containerd.sock
         kubeletExtraArgs:
           node-labels: node-role.kubernetes.io/worker=
-          feature-gates: ExperimentalCriticalPodAnnotation=true
     extraArgs:
     - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
   trustd:


### PR DESCRIPTION
I've added a README. This should smooth out some of the dev workflow.
We now have support for running a single-node.

I did discover that we can't read /dev/kmsg anymore since we're no longer mounting it.
(docker cp doesn't work) -- maybe there's another way to tail that device.

We should consider adding back the file-based logging hacks -- I'll leave that out of scope in this patch.

Changes:
- fix(hack): improve KubeletConfiguration for dev userdata
- feat(hack): add osctl/kubelet dev tooling and document usage