### PR TITLE
chore(tools): use Go compiler from toolchain image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ WORKDIR /blockd
 COPY ./internal/app/blockd/proto ./proto
 RUN protoc -I/usr/local/include -I./proto --go_out=plugins=grpc:proto proto/api.proto
 
-ARG GOLANG_VERSION
-FROM golang:${GOLANG_VERSION}-alpine AS golang-musl
-
 # The base target provides a common starting point for all other targets.
 
 ARG TOOLCHAIN_IMAGE
@@ -71,12 +68,8 @@ RUN ln -s /toolchain/bin/pwd /bin/pwd && \
     cp /tmp/syslinux/bios/extlinux/extlinux /rootfs/bin && \
     cp /tmp/syslinux/efi64/mbr/gptmbr.bin /rootfs/share
 # golang
-ENV GOROOT /toolchain/usr/local/go
-ENV GOPATH /toolchain/go
-COPY --from=golang-musl /usr/local/go ${GOROOT}
-ENV PATH ${PATH}:${GOROOT}/bin
+ENV GOPATH /toolchain/gopath
 RUN mkdir -p ${GOPATH}
-RUN ln -s lib /lib64
 # context
 ENV GO111MODULE on
 ENV CGO_ENABLED 0

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PUSH = $(shell gitmeta pushable)
 
 VPATH = $(PATH)
 KERNEL_IMAGE ?= autonomy/kernel:e8147aa
-TOOLCHAIN_IMAGE ?= autonomy/toolchain:80f91fd
+TOOLCHAIN_IMAGE ?= autonomy/toolchain:0341dfd
 GOLANG_VERSION ?= 1.12
 DOCKER_ARGS ?=
 BUILDKIT_VERSION ?= v0.3.3


### PR DESCRIPTION
This depends on autonomy/toolchain-musl#7.

Instead of "stealing" Go compiler from `golang` official Docker image,
use Go already baked into our toolchain image.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>