### PR TITLE
chore: improve error reporting in osctl cli

### DIFF
--- a/internal/app/osctl/internal/helpers/cli.go
+++ b/internal/app/osctl/internal/helpers/cli.go
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Fatalf prints formatted message to stderr and aborts execution
+func Fatalf(message string, args ...interface{}) {
+	if !strings.HasSuffix(message, "\n") {
+		message += "\n"
+	}
+
+	fmt.Fprintf(os.Stderr, message, args...)
+	os.Exit(1)
+}

--- a/internal/app/osctl/internal/helpers/should.go
+++ b/internal/app/osctl/internal/helpers/should.go
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package helpers
+
+// Should panics if err != nil
+//
+// Should is useful when error should never happen in customer environment,
+// it can only be development error.
+func Should(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
For any error which should be reported back to the user,
`helpers.Fatalf` is being used which prints message to
stderr and aborts with error.

Errors which can only happen during development,
`helpers.Should` is used to produce enough context.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>