### PR TITLE
chore: split ignorePreflightErrors as settings on its own

### DIFF
--- a/hack/dev/userdata/.master-1.tpl.yaml
+++ b/hack/dev/userdata/.master-1.tpl.yaml
@@ -5,7 +5,6 @@ services:
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: InitConfiguration
-      apiVersion: kubeadm.k8s.io/v1beta1
       bootstrapTokens:
       - token: 1qbsj9.3oz5hsk6grdfp98b
         ttl: 0s
@@ -37,9 +36,10 @@ services:
       conntrack:
         max: 0
         maxPerCore: 0
-    extraArgs:
-      - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
-        # additions to talos default are:  FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
+    ignorePreflightErrors:
+      - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
+      - Swap
+      - SystemVerification
   trustd:
     username: 'dev'
     password: 'talos_trust_dev'

--- a/hack/dev/userdata/.master-2.tpl.yaml
+++ b/hack/dev/userdata/.master-2.tpl.yaml
@@ -25,8 +25,10 @@ services:
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
-    extraArgs:
-    - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
+    ignorePreflightErrors:
+      - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
+      - Swap
+      - SystemVerification
   trustd:
     username: dev
     password: talos_trust_dev

--- a/hack/dev/userdata/.master-3.tpl.yaml
+++ b/hack/dev/userdata/.master-3.tpl.yaml
@@ -25,8 +25,10 @@ services:
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
-    extraArgs:
-    - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
+    ignorePreflightErrors:
+      - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
+      - Swap
+      - SystemVerification
   trustd:
     username: dev
     password: talos_trust_dev

--- a/hack/dev/userdata/.worker.tpl.yaml
+++ b/hack/dev/userdata/.worker.tpl.yaml
@@ -23,8 +23,10 @@ services:
         criSocket: /run/containerd/containerd.sock
         kubeletExtraArgs:
           node-labels: node-role.kubernetes.io/worker=
-    extraArgs:
-    - --ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,Swap
+    ignorePreflightErrors:
+      - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables
+      - Swap
+      - SystemVerification
   trustd:
     username: dev
     password: talos_trust_dev

--- a/internal/app/init/pkg/system/services/kubeadm.go
+++ b/internal/app/init/pkg/system/services/kubeadm.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/autonomy/talos/internal/app/init/internal/security/cis"
@@ -110,7 +111,9 @@ func (k *Kubeadm) Start(data *userdata.UserData) error {
 		ID: k.ID(data),
 	}
 
-	ignore := "--ignore-preflight-errors=cri,kubeletversion,numcpu,requiredipvskernelmodulesavailable"
+	ignorePreflightErrors := []string{"cri", "kubeletversion", "numcpu", "requiredipvskernelmodulesavailable"}
+	ignorePreflightErrors = append(ignorePreflightErrors, data.Services.Kubeadm.IgnorePreflightErrors...)
+	ignore := "--ignore-preflight-errors=" + strings.Join(ignorePreflightErrors, ",")
 	encoded := hex.EncodeToString([]byte(data.Services.Kubeadm.CertificateKey))
 	certificateKey := "--certificate-key=" + encoded
 

--- a/internal/pkg/userdata/userdata.go
+++ b/internal/pkg/userdata/userdata.go
@@ -134,23 +134,26 @@ type Kubelet struct {
 type Kubeadm struct {
 	CommonServiceOptions `yaml:",inline"`
 
-	Configuration  runtime.Object `yaml:"configuration"`
-	ExtraArgs      []string       `yaml:"extraArgs,omitempty"`
-	CertificateKey string         `yaml:"certificateKey,omitempty"`
-	bootstrap      bool
-	controlPlane   bool
+	Configuration         runtime.Object `yaml:"configuration"`
+	ExtraArgs             []string       `yaml:"extraArgs,omitempty"`
+	CertificateKey        string         `yaml:"certificateKey,omitempty"`
+	IgnorePreflightErrors []string       `yaml:"ignorePreflightErrors,omitempty"`
+	bootstrap             bool
+	controlPlane          bool
 }
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (kdm *Kubeadm) MarshalYAML() (interface{}, error) {
 	var aux struct {
-		Configuration  string   `yaml:"configuration,omitempty"`
-		ExtraArgs      []string `yaml:"extraArgs,omitempty"`
-		CertificateKey string   `yaml:"certificateKey,omitempty"`
+		Configuration         string   `yaml:"configuration,omitempty"`
+		ExtraArgs             []string `yaml:"extraArgs,omitempty"`
+		CertificateKey        string   `yaml:"certificateKey,omitempty"`
+		IgnorePreflightErrors []string `yaml:"ignorePreflightErrors,omitempty"`
 	}
 
 	aux.ExtraArgs = kdm.ExtraArgs
 	aux.CertificateKey = kdm.CertificateKey
+	aux.IgnorePreflightErrors = kdm.IgnorePreflightErrors
 
 	b, err := configutil.MarshalKubeadmConfigObject(kdm.Configuration)
 	if err != nil {
@@ -177,9 +180,10 @@ func (kdm *Kubeadm) MarshalYAML() (interface{}, error) {
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (kdm *Kubeadm) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var aux struct {
-		Configuration  string   `yaml:"configuration,omitempty"`
-		ExtraArgs      []string `yaml:"extraArgs,omitempty"`
-		CertificateKey string   `yaml:"certificateKey,omitempty"`
+		Configuration         string   `yaml:"configuration,omitempty"`
+		ExtraArgs             []string `yaml:"extraArgs,omitempty"`
+		CertificateKey        string   `yaml:"certificateKey,omitempty"`
+		IgnorePreflightErrors []string `yaml:"ignorePreflightErrors,omitempty"`
 	}
 
 	if err := unmarshal(&aux); err != nil {
@@ -188,6 +192,7 @@ func (kdm *Kubeadm) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	kdm.ExtraArgs = aux.ExtraArgs
 	kdm.CertificateKey = aux.CertificateKey
+	kdm.IgnorePreflightErrors = aux.IgnorePreflightErrors
 
 	b := []byte(aux.Configuration)
 


### PR DESCRIPTION
This allows to merge core ignore list and any user overrides
applied on top of it.

I've added yet another default ignore for docker-compose environment:
`SystemVerification` which fails for me while trying to verify config of
the Linux kernel.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>